### PR TITLE
Cipher List Setting

### DIFF
--- a/Source/TCPSSLConnection.swift
+++ b/Source/TCPSSLConnection.swift
@@ -29,13 +29,20 @@ public struct TCPSSLConnection: Connection {
     public let connection: TCPConnection
     public let stream: SSLClientStream
 
-    public init(host: String, port: Int, verifyBundle: String? = nil, certificate: String? = nil, privateKey: String? = nil, certificateChain: String? = nil, SNIHostname: String? = nil) throws {
+    public init(host: String, port: Int,
+              verifyBundle: String? = nil,
+              certificate: String? = nil,
+              privateKey: String? = nil,
+              certificateChain: String? = nil,
+              SNIHostname: String? = nil,
+              cipherList: String? = nil) throws {
         self.connection = try TCPConnection(host: host, port: port)
         let context = try SSLClientContext(
             verifyBundle: verifyBundle,
             certificate: certificate,
             privateKey: privateKey,
-            certificateChain: certificateChain
+            certificateChain: certificateChain,
+            cipherList: cipherList
         )
         self.stream = try SSLClientStream(context: context, rawStream: connection, SNIHostname: SNIHostname)
     }


### PR DESCRIPTION
# Problem

can not connect some site. e.g. https://echo.websocket.org
https://www.ssllabs.com/ssltest/analyze.html?d=echo.websocket.org
Safari can respond 404 but HTTPSClient reset connection by peer
# Reason

default cipher list `"HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"` is strict
so some server does not reach its requirement.
# Fix

Able to set cipherList from HTTPSClient it can pass to TCPSSL and then
OpenSSL

it does not break current program because it uses `cipherList: String?
= nil` so exsist code runs exactly it was before.
